### PR TITLE
V2.3.0 alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,43 @@ data: null
 */
 ```
 
+## Options for validate:
+| Option     | Description |
+|------------|-------------|
+| `whitelist` | If the value is `true`, it will clean all properties that are not defined in the schema. If the value is `false`, it will not perform the cleaning and allow the existence of additional properties in the object. This option is useful for validating and ensuring that the data sent to the class object is as expected. |
+---
+## How to avoid cleaning extra properties from my schema
+```javascript
+
+const okRawProductData = {
+  title: "title1",
+  price: 300.5,
+  extraProperty: true
+}
+
+const {
+  // Boolean indicating whether the object is valid or not
+  isValidate,
+  // validated object, can be null or an object with processed data ready to be used.
+  data, 
+  // object of errors produced during validation, can be null if the object is valid.
+  errors
+} = validate( createProductSchema, badRawProductData, { whitelist: false } )
+
+console.log({errors, isValidate, data})
+/*
+errors: null,
+isValidate: true,
+data: {
+  title: "title1",
+  price: 300.5,
+  active: true,
+  categories: ["category"],
+  extraProperty: true --> Here is the property thanks to whitelist false attribute
+}
+*/
+```
+
 ## Shortcut for schema creation:
 
 There is a way to shorten our schemas by leaving the default schema values to do their magic.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Welcome to Basic Valid Object Schema 👋
-![Version](https://img.shields.io/badge/version-0.2.2-blue.svg?cacheSeconds=2592000)
+![Version](https://img.shields.io/badge/version-0.2.3-blue.svg?cacheSeconds=2592000)
 ![Prerequisite](https://img.shields.io/badge/npm-%3E%3D8.0.0-blue.svg)
 ![Prerequisite](https://img.shields.io/badge/node-%3E%3D14.0.0-blue.svg)
 [![English- Documentation](https://img.shields.io/badge/documentation-yes-brightgreen.svg)](https://github.com/ifritzler/basic-valid-object-schema#readme)
 [![Spanish- Documentation](https://img.shields.io/badge/documentation-yes-brightgreen.svg)](https://github.com/ifritzler/basic-valid-object-schema/docs/spanish.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/ifritzler/basic-valid-object-schema/graphs/commit-activity)
-[![License: MIT](https://img.shields.io/github/license/ifritzler/Basic)](https://github.com/ifritzler/basic-valid-object-schema/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/github/license/ifritzler/Basic)](https://github.com/ifritzler/basic-valid-object-schema/blob/master/LICENSE.md)
 
 ---
 

--- a/docs/spanish.md
+++ b/docs/spanish.md
@@ -57,10 +57,10 @@ npm run test
 ---
 ## Metodos
 
-### ValidationObject.prototype.constructor(schema: object)
-### ValidationObject.prototype.validate(o: object)
+### BasicValidationClass.prototype.constructor(schema: object): BasicValidationClass
+### BasicValidationClass.prototype.validate(o: object): {errors, data, isValidate}
 - Metodo que valida un objeto contra el schema inicializado en la instancia de ValidationObject.
-
+### validate(schema: object, o: object): {errors, data, isValidate}
 - Return: {errors: object, data: null | object, isValidate: boolean}
 ---
 ## Uso/Ejemplos
@@ -75,7 +75,7 @@ Una vez creado el schema, donde queramos realizar la validacion necesitaremos im
 **Por defecto todas las propiedades de un schema son requeridas salvo que se indique lo contrario.**
 
 ```javascript
-import ValidationObject from 'basic-valid-object-schema';
+import { validate } from 'basic-valid-object-schema';
 
 const createProductSchema = {
     title: {
@@ -105,8 +105,6 @@ const okRawProductData = {
   price: 300.5
 }
 
-const validator = new ValidationObject(createProductSchema)
-
 const {
   // Booleano que indica si el objeto es valido o no
   isValidate,
@@ -114,7 +112,7 @@ const {
   data, 
   // object de errores producidos durante validacion, puede ser null en caso de que sea valido el objeto.
   errors
-} = validator.validate( badRawProductData )
+} = validate( createProductSchema, badRawProductData )
 
 console.log({errors, isValidate, data})
 /*
@@ -140,7 +138,7 @@ const badRawProductData = {
   price: "$300.5"
 }
 
-const { isValidate, data, errors } = validator.validate( badRawProductData )
+const { isValidate, data, errors } = validate( createProductSchema, badRawProductData )
 
 console.log({errors, isValidate, data})
 /*
@@ -151,6 +149,43 @@ errors: {
 },
 isValidate: false,
 data: null
+*/
+```
+
+## Opciones para validate:
+| Opción     | Descripción |
+|------------|-------------|
+| `whitelist` | Si el valor es `true`, limpiará todas las propiedades que no estén definidas en el schema. Si el valor es `false`, no realizará la limpieza y permitirá la existencia de propiedades adicionales en el objeto. Esta opción es útil para validar y asegurar que los datos enviados al objeto de la clase son los esperados. |
+---
+## Como evitar que se limpien las propiedades extras a mi schema
+```javascript
+
+const okRawProductData = {
+  title: "title1",
+  price: 300.5,
+  extraProperty: true
+}
+
+const {
+  // Booleano que indica si el objeto es valido o no
+  isValidate,
+  // objeto validado, puede ser null o un object con los datos procesados y listos para ser utilizados.
+  data, 
+  // object de errores producidos durante validacion, puede ser null en caso de que sea valido el objeto.
+  errors
+} = validate( createProductSchema, badRawProductData, { whitelist: false } )
+
+console.log({errors, isValidate, data})
+/*
+errors: null,
+isValidate: true,
+data: {
+  title: "title1",
+  price: 300.5,
+  active: true,
+  categories: ["category"],
+  extraProperty: true --> Here is the property thanks to whitelist false attribute
+}
 */
 ```
 

--- a/docs/spanish.md
+++ b/docs/spanish.md
@@ -1,11 +1,11 @@
 # Welcome to Basic Valid Object Schema 👋
-![Version](https://img.shields.io/badge/version-0.2.2-blue.svg?cacheSeconds=2592000)
+![Version](https://img.shields.io/badge/version-0.2.3-blue.svg?cacheSeconds=2592000)
 ![Prerequisite](https://img.shields.io/badge/npm-%3E%3D7.0.0-blue.svg)
 ![Prerequisite](https://img.shields.io/badge/node-%3E%3D12.0.0-blue.svg)
 [![English- Documentation](https://img.shields.io/badge/documentation-yes-brightgreen.svg)](https://github.com/ifritzler/basic-valid-object-schema#readme)
 [![Spanish- Documentation](https://img.shields.io/badge/documentation-yes-brightgreen.svg)](https://github.com/ifritzler/basic-valid-object-schema/docs/spanish.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/ifritzler/basic-valid-object-schema/graphs/commit-activity)
-[![License: MIT](https://img.shields.io/github/license/ifritzler/Basic)](https://github.com/ifritzler/basic-valid-object-schema/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/github/license/ifritzler/Basic)](https://github.com/ifritzler/basic-valid-object-schema/blob/master/LICENSE.md)
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-prototype-builtins */
 /* eslint-disable valid-typeof */
-class ValidationObject {
+class BasicValidationClass {
   #errors
   #schema
   constructor (schema) {
@@ -184,25 +184,14 @@ class ValidationObject {
     }
   }
 
-  /**
-   * Setea un error en el objeto de errores `#errors` en la clave dada por `parentKeys` y `key`.
-   * Si `parentKeys` es `null`, entonces la clave del error será `key`.
-   * Si `key` es `null`, entonces se trata de un error genérico para todos los elementos de un array.
-   *
-   * @private
-   * @param {?string[]} parentKeys - Un array con las claves de las propiedades padres del objeto, en orden descendente.
-   * @param {?string} key - La clave de la propiedad del objeto donde ocurrió el error.
-   * @param {string} error - El mensaje de error a asignar.
-   * @returns {void}
-   */
-  validate (obj, depth = 0, schema = this.#schema) {
+  validate (obj, options = DEFAULT_BASIC_VALID_SCHEMA_OPTIONS, depth = 0, schema = this.#schema) {
     this.#asignedDefaultValues(schema, obj)
     for (const prop in obj) {
       if (typeof obj[prop] === 'object' && obj[prop] !== null) {
         if (!Array.isArray(obj[prop])) {
-          this.validate(obj[prop], depth + 1, schema[prop]?.schema)
+          this.validate(obj[prop], options, depth + 1, schema[prop]?.schema)
         }
-      } else if (!schema[prop]) {
+      } else if (options.whitelist && !schema[prop]) {
         delete obj[prop]
       }
     }
@@ -223,4 +212,25 @@ class ValidationObject {
   }
 }
 
-module.exports = ValidationObject
+const DEFAULT_BASIC_VALID_SCHEMA_OPTIONS = {
+  whitelist: true
+}
+
+const validate = async (schema, obj, options = DEFAULT_BASIC_VALID_SCHEMA_OPTIONS) => {
+  const validator = new BasicValidationClass(schema)
+  const { errors, data, isValidate } = validator.validate(obj, options)
+
+  return { errors, data, isValidate }
+}
+
+const validateSync = (schema, obj, options = DEFAULT_BASIC_VALID_SCHEMA_OPTIONS) => {
+  const validator = new BasicValidationClass(schema)
+  const { errors, data, isValidate } = validator.validate(obj, options)
+
+  return { errors, data, isValidate }
+}
+
+module.exports = BasicValidationClass
+module.exports.DEFAULT_BASIC_VALID_SCHEMA_OPTIONS = DEFAULT_BASIC_VALID_SCHEMA_OPTIONS
+module.exports.validate = validate
+module.exports.validateSync = validateSync

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-valid-object-schema",
-  "version": "0.2.2-alpha",
+  "version": "0.2.3-alpha",
   "description": "Validation tool or utility that allows for simple and fast validation of an object against a schema.",
   "main": "index.js",
   "type": "commonjs",

--- a/test/test-array-schemas.spec.js
+++ b/test/test-array-schemas.spec.js
@@ -1,4 +1,6 @@
+/* eslint-disable no-unused-vars */
 const ValidationObject = require('..')
+
 const baseSchema = {
   title: 'string',
   description: 'string',
@@ -55,7 +57,6 @@ describe('Implementation of array schemas', () => {
   test('when i pass a invalid array type schema, throw an error', () => {
     try {
       const testValidationObject = new ValidationObject({ baseSchema, categories: 'array' })
-      console.log(testValidationObject)
     } catch (error) {
       expect(error.message).toEqual('If prop are from type array, the schema needs to be an object with the type array and a valid schema')
     }
@@ -64,7 +65,6 @@ describe('Implementation of array schemas', () => {
   test('A valid array schema needs to have a schema prop assigned.', () => {
     try {
       const testValidationObject = new ValidationObject({ baseSchema, categories: { type: 'array' } })
-      console.log(testValidationObject)
     } catch (error) {
       expect(error.message).toEqual('A valid array schema needs to have a schema prop assigned.')
     }
@@ -73,7 +73,6 @@ describe('Implementation of array schemas', () => {
   test('A schema of an array must be a valid schema object or string primitive.', () => {
     try {
       const testValidationObject = new ValidationObject({ baseSchema, categories: { type: 'array', schema: ['hello i am an error'] } })
-      console.log(testValidationObject)
     } catch (error) {
       expect(error.message).toEqual('A schema of an array must be a valid schema object or string primitive.')
     }
@@ -101,7 +100,6 @@ describe('Implementation of array schemas', () => {
     }
 
     const { errors, data, isValidate } = testValidationObject.validate(inputObject)
-    console.log({ errors, data, isValidate })
 
     expect(errors).toStrictEqual({})
     expect(data).toStrictEqual(inputObject)
@@ -119,7 +117,6 @@ describe('Implementation of array schemas', () => {
     }
 
     const { errors, data, isValidate } = testValidationObject.validate(inputObject)
-    console.log({ errors, data, isValidate })
 
     expect(errors).toStrictEqual({ categories: { value: { error: 'value must be a valid number.' } } })
     expect(data).toBeNull()
@@ -137,7 +134,6 @@ describe('Implementation of array schemas', () => {
     }
 
     const { errors, data, isValidate } = testValidationObject.validate(inputObject)
-    console.log({ errors, data, isValidate })
 
     expect(errors).toStrictEqual({ categories: { error: "item with value '3' of array must be a valid string." } })
     expect(data).toBeNull()

--- a/test/test_validate_func.spec.js
+++ b/test/test_validate_func.spec.js
@@ -1,0 +1,189 @@
+const { validate } = require('..')
+
+const baseSchema = {
+  title: 'string',
+  description: 'string',
+  stock: 'number',
+  active: 'boolean',
+  categories: {
+    type: 'array',
+    schema: 'string'
+  }
+}
+
+describe('Validating a 1 level depth schema with primitive and non primitive types', () => {
+  test('input object is a valid schema', async () => {
+    const obj = { title: 'test title', description: 'test desc', stock: 25, active: true, categories: ['category'] }
+    const { isValidate, errors, data } = await validate(baseSchema, obj)
+    expect(isValidate).toBe(true)
+    expect(data).toStrictEqual({ title: 'test title', description: 'test desc', stock: 25, active: true, categories: ['category'] })
+    expect(errors).toStrictEqual({})
+  })
+
+  test('props are required by default', async () => {
+    const obj = { description: 'test desc', stock: 25, active: true, categories: ['category'] }
+    const { isValidate, errors, data } = await validate(baseSchema, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ title: { error: 'Is required' } })
+  })
+
+  test('prop number must be a valid number', async () => {
+    const obj = { title: 'test title', description: 'test desc', stock: '25', active: true, categories: ['category'] }
+    const { isValidate, errors, data } = await validate(baseSchema, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ stock: { error: 'stock must be a valid number.' } })
+  })
+
+  test('prop string must be a valid string', async () => {
+    const obj = { title: 'test title', description: 2, stock: 25, active: true, categories: ['category'] }
+    const { isValidate, errors, data } = await validate(baseSchema, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ description: { error: 'description must be a valid string.' } })
+  })
+
+  test('prop boolean must be a valid boolean', async () => {
+    const obj = { title: 'test title', description: 'test desc', stock: 25, active: 'true', categories: ['category'] }
+    const { isValidate, errors, data } = await validate(baseSchema, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ active: { error: 'active must be a valid boolean.' } })
+  })
+
+  test('prop array must be a valid array', async () => {
+    const obj = { title: 'test title', description: 'test desc', stock: 25, active: true, categories: 'category' }
+    const { isValidate, errors, data } = await validate(baseSchema, obj)
+    expect(isValidate).toBe(false)
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ categories: { error: 'categories must be a valid array.' } })
+  })
+})
+
+describe('Validating a 2 level depth schema with primitive and non primitive types', () => {
+  const baseSchemaModify = { ...baseSchema, origin: { schema: { country: 'string', city: 'string' } } }
+  const baseTestItem = { title: 'test title', description: 'test desc', stock: 25, active: true, categories: ['category'], origin: { country: 'Argentina', city: 'MDP' } }
+  test('input object is a valid schema', async () => {
+    const obj = JSON.parse(JSON.stringify(baseTestItem))
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    expect(isValidate).toBe(true)
+    expect(data).toStrictEqual(baseTestItem)
+    expect(errors).toStrictEqual({})
+  })
+
+  test('props first level - required by default', async () => {
+    const { origin, ...obj } = JSON.parse(JSON.stringify(baseTestItem))
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ origin: { error: 'Is required' } })
+  })
+
+  test('props second level - required by default', async () => {
+    const obj = JSON.parse(JSON.stringify(baseTestItem))
+    delete obj.origin.city
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ origin: { city: { error: 'Is required' } } })
+  })
+
+  test('prop number must be a valid number', async () => {
+    const obj = JSON.parse(JSON.stringify({ ...baseTestItem, stock: '25' }))
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ stock: { error: 'stock must be a valid number.' } })
+  })
+
+  test('prop string must be a valid string', async () => {
+    const obj = JSON.parse(JSON.stringify({ ...baseTestItem, origin: { ...baseTestItem.origin, city: 12 } }))
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    expect(isValidate).toBeFalsy()
+    expect(data).toBeNull()
+    expect(errors).toStrictEqual({ origin: { city: { error: 'city must be a valid string.' } } })
+  })
+})
+
+describe('Validating default values', () => {
+  const baseSchemaModify = {
+    ...baseSchema,
+    title: { type: 'string', default: 'title' },
+    origin: {
+      schema: {
+        country: {
+          type: 'string',
+          default: 'Argentina'
+        },
+        city: 'string'
+      }
+    }
+  }
+  const inputTestItem = { description: 'test desc', stock: 25, active: true, categories: ['category'], origin: { city: 'MDP' } }
+
+  test('if a prop have a default value and does not on input object, then default value appears', async () => {
+    const obj = JSON.parse(JSON.stringify(inputTestItem))
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    const responseTestItem = { title: 'title', description: 'test desc', stock: 25, active: true, categories: ['category'], origin: { country: 'Argentina', city: 'MDP' } }
+    expect(isValidate).toBe(true)
+    expect(data).toStrictEqual(responseTestItem)
+    expect(errors).toStrictEqual({})
+  })
+})
+
+describe('Validating non required values', () => {
+  const baseSchemaModify = { ...baseSchema, title: { type: 'string', required: false } }
+  const inputTestItem = { description: 'test desc', stock: 25, active: true, categories: ['category'] }
+
+  test('if a prop is a non required field ignore it', async () => {
+    const obj = JSON.parse(JSON.stringify(inputTestItem))
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    const responseTestItem = { description: 'test desc', stock: 25, active: true, categories: ['category'] }
+    expect(errors).toStrictEqual({})
+    expect(data).toStrictEqual(responseTestItem)
+    expect(isValidate).toBe(true)
+  })
+})
+
+describe('Deleting all fields that not match with the schema', () => {
+  const baseSchemaModify = { ...baseSchema, title: { type: 'string', required: false } }
+  const inputTestItem = { title: 'test title', description: 'test desc', stock: 25, active: true, categories: ['category'], saraza: 'saraza', query: 'SELECT *' }
+
+  test('if a prop is a non required field ignore it', async () => {
+    const obj = JSON.parse(JSON.stringify(inputTestItem))
+    const { isValidate, errors, data } = await validate(baseSchemaModify, obj)
+    const responseTestItem = { title: 'test title', description: 'test desc', stock: 25, active: true, categories: ['category'] }
+    expect(errors).toStrictEqual({})
+    expect(data).toStrictEqual(responseTestItem)
+    expect(isValidate).toBe(true)
+  })
+
+  test('case with a prop object that is not an array but have schema', async () => {
+    const baseSchemaModify2 = { ...baseSchema, address: { schema: { street: 'string', number: 'number' } } }
+    const obj = JSON.parse(JSON.stringify({ ...inputTestItem, address: { street: 'Street', number: 123 } }))
+    const { isValidate, errors, data } = await validate(baseSchemaModify2, obj)
+    const responseTestItem = { title: 'test title', description: 'test desc', stock: 25, active: true, categories: ['category'], address: { street: 'Street', number: 123 } }
+    expect(errors).toStrictEqual({})
+    expect(data).toStrictEqual(responseTestItem)
+    expect(isValidate).toBe(true)
+  })
+})
+
+describe('Verify data with whitelist false works', () => {
+  test('first level', async () => {
+    const { data, errors, isValidate } = await validate(baseSchema, { title: '1', description: '2', price: 3, stock: 4, active: true, categories: ['6', '7'], saraza: true }, { whitelist: false })
+    expect(errors).toStrictEqual({})
+    expect(data).not.toBeNull()
+    expect(data.saraza).toBeDefined()
+    expect(isValidate).toBe(true)
+  })
+
+  test('second level', async () => {
+    const { data, errors, isValidate } = await validate({ ...baseSchema, address: { schema: { street: 'string', number: 'number' } } }, { title: '1', description: '2', price: 3, stock: 4, active: true, categories: ['6', '7'], address: { street: 'strobel', number: 4051, saraza: true } }, { whitelist: false })
+    expect(errors).toStrictEqual({})
+    expect(data).not.toBeNull()
+    expect(data.address.saraza).toBeDefined()
+    expect(isValidate).toBe(true)
+  })
+})


### PR DESCRIPTION
## English:
Breaking changes:

- The name of the ValidationObject class has been changed to **BasicValidationClass**.
- The `validate` function has been added, which allows you to avoid instantiating the BasicValidationClass and use its `validate` method instead.
- Now it is possible to pass an options object through the `validate` utility function
  - `whitelist`: its default value is true. If set to false, it will avoid cleaning properties that come in the object that do not match the schema.
- Documentation and version have been updated.

## Spanish

Breaking changes:

- Se cambio el nombre de la clase ValidationObject por **BasicValidationClass**
- Se agrego la funcion `validate` que permite evitar instanciar la clase BasicValidationClass y utilizar su metodo `validate`.
- Ahora es posible mediante la funcion de utilidad `validate` pasar un objeto de opciones 
  - `whitelist`: por defecto su valor es true, si se coloca en false evitara limpiar propiedades que vengan en el objeto que no coincidan con el schema.}
- Se actualizo documentacion y version.